### PR TITLE
Fixed issue with encrypting and decrypting maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ For signing, the user specified signing key can be either symmetric or asymmetri
 
 ## Known Limitations
 
-1. Currently the new data types in [Amazon DynamoDB][ddb] including Map, List, Boolean, and NULL are not yet supported by this library.  In particular, this library would fail fast upon detecting the use of these new data types.  We expect to support the new types soon in future releases.
+1. Currently the new data types in [Amazon DynamoDB][ddb] including List, Boolean, and NULL are supported, but not fully tested by this library.  Map support has been added and tested.  We expect to support the other new types soon in future releases.
 
 2. During retrieval of an item, all the attributes of the item that have been involved for encryption or signing must also be included for signature verification.  Otherwise, the signature would fail to verify.
 

--- a/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/DynamoDBEncryptor.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/DynamoDBEncryptor.java
@@ -353,11 +353,10 @@ public class DynamoDBEncryptor {
                                                  int ivSize) throws GeneralSecurityException {
         // Recursively call through map attributes
         if (value.getM() != null) {
-            Map<String, AttributeValue> decryptedMap = new HashMap<>(value.getM());
-            for (Map.Entry<String, AttributeValue> entry : decryptedMap.entrySet()) {
+            for (Map.Entry<String, AttributeValue> entry : value.getM().entrySet()) {
                 entry.setValue(decryptAttributeValue(entry.getValue(), encryptionKey, encryptionMode, cipher, ivSize));
             }
-            return new AttributeValue().withM(decryptedMap);
+            return value;
         }
 
         ByteBuffer plainText;
@@ -418,11 +417,10 @@ public class DynamoDBEncryptor {
                                                  int ivSize) throws GeneralSecurityException {
         // Recursively call through map attributes
         if (value.getM() != null) {
-            Map<String, AttributeValue> encryptedMap = new HashMap<>(value.getM());
-            for (Map.Entry<String, AttributeValue> entry : encryptedMap.entrySet()) {
+            for (Map.Entry<String, AttributeValue> entry : value.getM().entrySet()) {
                 entry.setValue(encryptAttributeValue(entry.getValue(), encryptionKey, encryptionMode, cipher, ivSize));
             }
-            return new AttributeValue().withM(encryptedMap);
+            return value;
         }
 
         ByteBuffer plainText = AttributeValueMarshaller.marshall(value);

--- a/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/AttributeEncryptorTest.java
+++ b/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/AttributeEncryptorTest.java
@@ -113,8 +113,6 @@ public class AttributeEncryptorTest {
         assertThat(encryptedAttributes, AttrMatcher.invert(attribs));
         params = FakeParameters.getInstance(BaseClass.class, encryptedAttributes, null, TABLE_NAME,
                 HASH_KEY, RANGE_KEY);
-        Map<String, AttributeValue> decryptedAttributes = encryptor.untransform(params);
-        assertThat(decryptedAttributes, AttrMatcher.match(attribs));
 
         // Make sure keys and version are not encrypted
         assertAttrEquals(attribs.get(HASH_KEY), encryptedAttributes.get(HASH_KEY));
@@ -129,6 +127,9 @@ public class AttributeEncryptorTest {
         assertNull(encryptedAttributes.get("mapValue").getM().get("key2").getS());
         assertNotNull(encryptedAttributes.get("mapValue").getM().get("key1").getB());
         assertNotNull(encryptedAttributes.get("mapValue").getM().get("key2").getB());
+
+        Map<String, AttributeValue> decryptedAttributes = encryptor.untransform(params);
+        assertThat(decryptedAttributes, AttrMatcher.match(attribs));
     }
 
     @Test(expected = DynamoDBMappingException.class)
@@ -284,8 +285,6 @@ public class AttributeEncryptorTest {
         assertThat(encryptedAttributes, AttrMatcher.invert(attribs));
         params = FakeParameters.getInstance(Mixed.class, encryptedAttributes, null, TABLE_NAME,
                 HASH_KEY, RANGE_KEY);
-        Map<String, AttributeValue> decryptedAttributes = encryptor.untransform(params);
-        assertThat(decryptedAttributes, AttrMatcher.match(attribs));
 
         // Make sure keys and version are not encrypted
         assertAttrEquals(attribs.get(HASH_KEY), encryptedAttributes.get(HASH_KEY));
@@ -310,7 +309,7 @@ public class AttributeEncryptorTest {
 
         params = FakeParameters.getInstance(Mixed.class, encryptedAttributes, null, TABLE_NAME,
                 HASH_KEY, RANGE_KEY);
-        decryptedAttributes = encryptor.untransform(params);
+        Map<String, AttributeValue> decryptedAttributes = encryptor.untransform(params);
         assertThat(decryptedAttributes, AttrMatcher.match(attribs));
     }
 

--- a/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/AttributeEncryptorTest.java
+++ b/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/AttributeEncryptorTest.java
@@ -91,6 +91,10 @@ public class AttributeEncryptorTest {
         attribs.put(HASH_KEY, new AttributeValue().withN("5"));
         attribs.put(RANGE_KEY, new AttributeValue().withN("7"));
         attribs.put("version", new AttributeValue().withN("0"));
+        Map<String, AttributeValue> map = new HashMap<>();
+        map.put("key1", new AttributeValue().withS("value1"));
+        map.put("key2", new AttributeValue().withS("value2"));
+        attribs.put("mapValue", new AttributeValue().withM(map));
     }
 
     @Test
@@ -121,6 +125,10 @@ public class AttributeEncryptorTest {
         assertTrue(encryptedAttributes.containsKey("stringValue"));
         assertNull(encryptedAttributes.get("stringValue").getS());
         assertNotNull(encryptedAttributes.get("stringValue").getB());
+        assertNull(encryptedAttributes.get("mapValue").getM().get("key1").getS());
+        assertNull(encryptedAttributes.get("mapValue").getM().get("key2").getS());
+        assertNotNull(encryptedAttributes.get("mapValue").getM().get("key1").getB());
+        assertNotNull(encryptedAttributes.get("mapValue").getM().get("key2").getB());
     }
 
     @Test(expected = DynamoDBMappingException.class)
@@ -170,6 +178,9 @@ public class AttributeEncryptorTest {
 
         // Make sure String has not been encrypted (we'll assume the others are correct as well)
         assertAttrEquals(attribs.get("stringValue"), encryptedAttributes.get("stringValue"));
+
+        assertEquals(encryptedAttributes.get("mapValue").getM().get("key1").getS(), "value1");
+        assertEquals(encryptedAttributes.get("mapValue").getM().get("key2").getS(), "value2");
     }
 
     @Test
@@ -192,6 +203,9 @@ public class AttributeEncryptorTest {
 
         // Make sure String has not been encrypted (we'll assume the others are correct as well)
         assertAttrEquals(attribs.get("stringValue"), encryptedAttributes.get("stringValue"));
+
+        assertEquals(encryptedAttributes.get("mapValue").getM().get("key1").getS(), "value1");
+        assertEquals(encryptedAttributes.get("mapValue").getM().get("key2").getS(), "value2");
     }
 
     @Test(expected = DynamoDBMappingException.class)
@@ -240,6 +254,9 @@ public class AttributeEncryptorTest {
 
         // Make sure String has not been encrypted (we'll assume the others are correct as well)
         assertAttrEquals(attribs.get("stringValue"), encryptedAttributes.get("stringValue"));
+
+        assertEquals(encryptedAttributes.get("mapValue").getM().get("key1").getS(), "value1");
+        assertEquals(encryptedAttributes.get("mapValue").getM().get("key2").getS(), "value2");
     }
 
     @Test(expected = DynamoDBMappingException.class)
@@ -279,6 +296,10 @@ public class AttributeEncryptorTest {
         assertTrue(encryptedAttributes.containsKey("stringSet"));
         assertNull(encryptedAttributes.get("stringSet").getSS());
         assertNotNull(encryptedAttributes.get("stringSet").getB());
+        assertNull(encryptedAttributes.get("mapValue").getM().get("key1").getS());
+        assertNull(encryptedAttributes.get("mapValue").getM().get("key2").getS());
+        assertNotNull(encryptedAttributes.get("mapValue").getM().get("key1").getB());
+        assertNotNull(encryptedAttributes.get("mapValue").getM().get("key2").getB());
 
         // Test those not encrypted
         assertAttrEquals(attribs.get("stringValue"), encryptedAttributes.get("stringValue"));
@@ -312,6 +333,7 @@ public class AttributeEncryptorTest {
         assertSetsEqual(o1.getNS(), o2.getNS());
         Assert.assertEquals(o1.getS(), o2.getS());
         assertSetsEqual(o1.getSS(), o2.getSS());
+        Assert.assertEquals(o1.getM(), o2.getM());
     }
 
     private <T> void assertSetsEqual(Collection<T> c1, Collection<T> c2) {

--- a/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/DynamoDBEncryptorTest.java
+++ b/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/DynamoDBEncryptorTest.java
@@ -127,10 +127,6 @@ public class DynamoDBEncryptorTest {
                 encryptor.encryptAllFieldsExcept(Collections.unmodifiableMap(attribs), context, "hashKey", "rangeKey", "version");
         assertThat(encryptedAttributes, AttrMatcher.invert(attribs));
 
-        Map<String, AttributeValue> decryptedAttributes =
-                encryptor.decryptAllFieldsExcept(Collections.unmodifiableMap(encryptedAttributes), context, "hashKey", "rangeKey", "version");
-        assertThat(decryptedAttributes, AttrMatcher.match(attribs));
-
         // Make sure keys and version are not encrypted
         assertAttrEquals(attribs.get("hashKey"), encryptedAttributes.get("hashKey"));
         assertAttrEquals(attribs.get("rangeKey"), encryptedAttributes.get("rangeKey"));
@@ -149,6 +145,10 @@ public class DynamoDBEncryptorTest {
         // Make sure we're calling the proper getEncryptionMaterials method
         assertEquals("Wrong getEncryptionMaterials() called", 
                 1, prov.getCallCount("getEncryptionMaterials(EncryptionContext context)"));
+
+        Map<String, AttributeValue> decryptedAttributes =
+                encryptor.decryptAllFieldsExcept(Collections.unmodifiableMap(encryptedAttributes), context, "hashKey", "rangeKey", "version");
+        assertThat(decryptedAttributes, AttrMatcher.match(attribs));
     }
 
     @Test
@@ -156,10 +156,11 @@ public class DynamoDBEncryptorTest {
         Map<String, AttributeValue> encryptedAttributes =
                 encryptor.encryptAllFieldsExcept(Collections.unmodifiableMap(attribs), context, "hashKey", "rangeKey", "version");
         String encryptedString = encryptedAttributes.toString();
-        Map<String, AttributeValue> decryptedAttributes =
-                encryptor.decryptAllFieldsExcept(Collections.unmodifiableMap(encryptedAttributes), context, "hashKey", "rangeKey", "version");
 
         assertEquals(encryptedString, encryptedAttributes.toString());
+
+        Map<String, AttributeValue> decryptedAttributes =
+                encryptor.decryptAllFieldsExcept(Collections.unmodifiableMap(encryptedAttributes), context, "hashKey", "rangeKey", "version");
     }
 
     @Test(expected=SignatureException.class)

--- a/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/DynamoDBEncryptorTest.java
+++ b/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/DynamoDBEncryptorTest.java
@@ -95,6 +95,10 @@ public class DynamoDBEncryptorTest {
         attribs.put("hashKey", new AttributeValue().withN("5"));
         attribs.put("rangeKey", new AttributeValue().withN("7"));
         attribs.put("version", new AttributeValue().withN("0"));
+        Map<String, AttributeValue> map = new HashMap<>();
+        map.put("key1", new AttributeValue().withS("value1"));
+        map.put("key2", new AttributeValue().withS("value2"));
+        attribs.put("map", new AttributeValue().withM(map));
 
         context = new EncryptionContext.Builder()
             .withTableName("TableName")
@@ -136,6 +140,11 @@ public class DynamoDBEncryptorTest {
         assertTrue(encryptedAttributes.containsKey("stringValue"));
         assertNull(encryptedAttributes.get("stringValue").getS());
         assertNotNull(encryptedAttributes.get("stringValue").getB());
+
+        assertNull(encryptedAttributes.get("map").getM().get("key1").getS());
+        assertNull(encryptedAttributes.get("map").getM().get("key2").getS());
+        assertNotNull(encryptedAttributes.get("map").getM().get("key1").getB());
+        assertNotNull(encryptedAttributes.get("map").getM().get("key2").getB());
 
         // Make sure we're calling the proper getEncryptionMaterials method
         assertEquals("Wrong getEncryptionMaterials() called", 
@@ -190,6 +199,7 @@ public class DynamoDBEncryptorTest {
         
         // Make sure String has not been encrypted (we'll assume the others are correct as well)
         assertAttrEquals(attribs.get("stringValue"), encryptedAttributes.get("stringValue"));
+        assertAttrEquals(attribs.get("map"), encryptedAttributes.get("map"));
     }
     
     @Test
@@ -210,6 +220,7 @@ public class DynamoDBEncryptorTest {
         
         // Make sure String has not been encrypted (we'll assume the others are correct as well)
         assertAttrEquals(attribs.get("stringValue"), encryptedAttributes.get("stringValue"));
+        assertAttrEquals(attribs.get("map"), encryptedAttributes.get("map"));
     }
     
     @Test(expected=SignatureException.class)
@@ -252,6 +263,7 @@ public class DynamoDBEncryptorTest {
         
         // Make sure String has not been encrypted (we'll assume the others are correct as well)
         assertAttrEquals(attribs.get("stringValue"), encryptedAttributes.get("stringValue"));
+        assertAttrEquals(attribs.get("map"), encryptedAttributes.get("map"));
     }
     
     @Test(expected=SignatureException.class)
@@ -287,6 +299,7 @@ public class DynamoDBEncryptorTest {
         
         // Make sure String has not been encrypted (we'll assume the others are correct as well)
         assertAttrEquals(attribs.get("stringValue"), encryptedAttributes.get("stringValue"));
+        assertAttrEquals(attribs.get("map"), encryptedAttributes.get("map"));
     }
     
     @Test(expected=SignatureException.class)
@@ -307,6 +320,7 @@ public class DynamoDBEncryptorTest {
         assertSetsEqual(o1.getNS(), o2.getNS());
         Assert.assertEquals(o1.getS(), o2.getS());
         assertSetsEqual(o1.getSS(), o2.getSS());
+        Assert.assertEquals(o1.getM(), o2.getM());
     }
     
     private <T> void assertSetsEqual(Collection<T> c1, Collection<T> c2) {

--- a/src/test/java/com/amazonaws/services/dynamodbv2/testing/types/BaseClass.java
+++ b/src/test/java/com/amazonaws/services/dynamodbv2/testing/types/BaseClass.java
@@ -15,12 +15,15 @@
 package com.amazonaws.services.dynamodbv2.testing.types;
 
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBRangeKey;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBVersionAttribute;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 
 @DynamoDBTable(tableName = "TableName")
 public class BaseClass {
@@ -40,6 +43,8 @@ public class BaseClass {
         result = prime * result + Double.valueOf(doubleValue).hashCode();
         result = prime * result
                 + ((doubleSet == null) ? 0 : doubleSet.hashCode());
+        result = prime * result
+                + ((mapValue == null) ? 0 : mapValue.hashCode());
         return result;
     }
     @Override
@@ -79,6 +84,11 @@ public class BaseClass {
                 return false;
         } else if (!doubleSet.equals(other.doubleSet))
             return false;
+        if (mapValue == null) {
+            if (other.mapValue != null)
+                return false;
+        } else if (!mapValue.equals(other.mapValue))
+            return false;
         return true;
     }
     private int hashKey;
@@ -91,6 +101,7 @@ public class BaseClass {
     private Integer version;
     private double doubleValue;
     private Set<Double> doubleSet;
+    private Map<String, AttributeValue> mapValue = new HashMap();
 
     @DynamoDBHashKey
     public int getHashKey() {
@@ -149,6 +160,15 @@ public class BaseClass {
     public void setDoubleValue(double doubleValue) {
         this.doubleValue = doubleValue;
     }
+
+    public Map<String, AttributeValue> getMapValue() {
+        return mapValue;
+    }
+
+    public void setMapValue(Map<String, AttributeValue> mapValue) {
+        this.mapValue = mapValue;
+    }
+
     @DynamoDBVersionAttribute
     public Integer getVersion() {
         return version;
@@ -162,6 +182,7 @@ public class BaseClass {
                 + ", stringValue=" + stringValue + ", intValue=" + intValue
                 + ", byteArrayValue=" + Arrays.toString(byteArrayValue)
                 + ", stringSet=" + stringSet + ", intSet=" + intSet
-                + ", doubleSet=" + doubleSet + ", version=" + version + "]";
+                + ", doubleSet=" + doubleSet + ", version=" + version
+                + ", mapValue=" + mapValue + "]";
     }
 }


### PR DESCRIPTION
Previously maps would contain both an encrypted B-value and a M-value which contained attributes with their own encrypted values. This fixes the encryption and decryption methods so they preserve the map elements, but the map does not have it's own B-value.