### PR TITLE
use AWS BOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,12 +32,23 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
-  
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.amazonaws</groupId>
+        <artifactId>aws-java-sdk-bom</artifactId>
+        <version>1.10.41</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk</artifactId>
-      <version>1.10.41</version>
+      <artifactId>aws-java-sdk-dynamodb</artifactId>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
use BOM to avoid downloading all aws dependencies, as described in http://docs.aws.amazon.com/AWSSdkDocsJava/latest/DeveloperGuide/java-dg-using-maven.html