### PR TITLE
Consume latest version of AWS SDK. 1.11.315

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
       <dependency>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-java-sdk-bom</artifactId>
-        <version>1.11.15</version>
+        <version>1.11.315</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Changes the listed dependency of this package to aws-java-sdk version 1.11.315 which gives us the new client builders.